### PR TITLE
fixed an issue where format could get a value that was too big

### DIFF
--- a/lua/qfview/init.lua
+++ b/lua/qfview/init.lua
@@ -158,7 +158,7 @@ function M.qftextfunc(info)
   local l = {}
   for idx = info.start_idx, info.end_idx do
     local line = string.format(
-      '%-' .. path_maxw .. 's' .. '|%-' .. linenr_maxw .. 's|%s',
+      '%-' .. math.min(path_maxw, 99) .. 's' .. '|%-' .. math.min(linenr_maxw, 99) .. 's|%s',
       stripped_paths[idx],
       linenrs[idx],
       texts[idx]
@@ -182,6 +182,5 @@ end
 function M.setup(options)
   vim.api.nvim_set_option('quickfixtextfunc', "v:lua.require'qfview'.qftextfunc")
 end
-
 
 return M


### PR DESCRIPTION
When the value for string.format gets above 99, then you get an error message saying "invalid option %-XXX for format". see e.g wincent/command-t#415

This fix only removes the error messages. If the length is over 99, then the format with 99 is not correct and it will be displayed incorrectly. I guess the correct thing would be to truncate. Personally i'm okay with it, in most cases looks okay. 


sorry about https://github.com/ashfinal/qfview.nvim/pull/1 , Something strange happed whit my push and i no longer trusted the changes, so i recreated the branch and PR. 