### PR TITLE
fix: unknown sign v:null

### DIFF
--- a/lua/qfview/init.lua
+++ b/lua/qfview/init.lua
@@ -14,7 +14,7 @@ local function get_common_prefix(matrix, shortest)
   local prefix = {}
   local idx = 1
   while true do
-    local c = matrix[1][idx]
+    local c = (matrix[1] or {})[idx]
     if c == nil then
       break
     end
@@ -166,15 +166,17 @@ function M.qftextfunc(info)
     )
     table.insert(l, line)
 
-    if types[idx] ~= '' then
-      vim.fn.sign_place(
-        0,
-        'qfviewSignGroup',
-        signs[types[idx]],
-        qflist.qfbufnr,
-        { lnum = idx, priority = 10 }
-      )
-    end
+    if types[idx] == '' then goto done end
+    if type(signs[types[idx]]) ~= 'string' then goto done end
+    if signs[types[idx]] == '' then goto done end
+    vim.fn.sign_place(
+      0,
+      'qfviewSignGroup',
+      signs[types[idx]],
+      qflist.qfbufnr,
+      { lnum = idx, priority = 10 }
+    )
+    ::done::
   end
 
   return l


### PR DESCRIPTION
When setting a quickfix list, an unknown, unset or empty type might be came
across, which caused this error:

NOTE: chuncks of this error message have been removed for brevity, but the
context is `overseer.nvim`'s `on_output_quickfix`. This set
```
[ERROR] Vim:E5108: Error executing lua Vim:E155: Unknown sign: v:null
stack traceback:
	[C]: in function 'sign_place'
	...qfview.nvim/lua/qfview/init.lua:170: in function <...qfview.nvim/lua/qfview/init.lua:53>
	[C]: in function 'setqflist'
```

This PR fixes that problem. It does a couple more null/empty checks before
actually calling `sign_place()`, which is very strict and does not want to
silently do nothing or through a warning, it just errors immediately.
